### PR TITLE
MIME types update

### DIFF
--- a/src/main/external-resources/renderers/DefaultRenderer.conf
+++ b/src/main/external-resources/renderers/DefaultRenderer.conf
@@ -607,7 +607,7 @@ CharMap =
 #    mp2      MPEG Audio Layer II                           audio/mpeg
 #    mp3      MPEG-1 or MPEG-2 Audio Layer III              audio/mpeg
 #    mp4      ISOM/MPEG4 container, or MPEG-4 codec         video/mp4                          For Video files
-#    mp4      ISOM/MPEG4 container, AAC-LC/HE-AAC/ALAC      audio/mp4                          For Audio files
+#    m4a      ISOM/MPEG4 container, AAC-LC/HE-AAC/ALAC      audio/mp4                          For Audio files
 #    mpa      MPEG Audio                                    audio/mpeg
 #    mpc      MusePack                                      audio/x-musepack
 #    mpeg1    MPEG-1                                        video/mpeg                         Used in VCDs
@@ -640,7 +640,7 @@ CharMap =
 #    vp8      Google VP8
 #    vp9      Google VP9
 #    wavpack  WavPack                                       audio/wavpack
-#    wav      Waveform Audio File Format                    audio/x-wav
+#    wav      Waveform Audio File Format                    audio/wav
 #    weba     Webm Audio                                    audio/webm
 #    webm     WebM Video                                    video/webm
 #    wma      Windows Media Audio                           audio/x-ms-wma

--- a/src/main/java/net/pms/network/HTTPResource.java
+++ b/src/main/java/net/pms/network/HTTPResource.java
@@ -58,7 +58,7 @@ public class HTTPResource {
 	public static final String AUDIO_EAC3_TYPEMIME = "audio/eac3";
 	public static final String AUDIO_FLAC_TYPEMIME = "audio/x-flac";
 	public static final String AUDIO_LPCM_TYPEMIME = "audio/L16";
-	public static final String AUDIO_M4A_TYPEMIME = "audio/x-m4a";
+	public static final String AUDIO_M4A_TYPEMIME = "audio/mp4";
 	public static final String AUDIO_MKA_TYPEMIME = "audio/x-matroska";
 	public static final String AUDIO_MLP_TYPEMIME = "audio/vnd.dolby.mlp";
 	public static final String AUDIO_MP3_TYPEMIME = "audio/mpeg";
@@ -73,7 +73,7 @@ public class HTTPResource {
 	public static final String AUDIO_TRUEHD_TYPEMIME = "audio/vnd.dolby.mlp";
 	public static final String AUDIO_TTA_TYPEMIME = "audio/x-tta";
 	public static final String AUDIO_VORBIS_TYPEMIME = "audio/ogg";
-	public static final String AUDIO_WAV_TYPEMIME = "audio/x-wav";
+	public static final String AUDIO_WAV_TYPEMIME = "audio/wav";
 	public static final String AUDIO_WEBM_TYPEMIME = "audio/webm";
 	public static final String AUDIO_WMA_TYPEMIME = "audio/x-ms-wma";
 	public static final String AUDIO_WV_TYPEMIME = "audio/x-wavpack";


### PR DESCRIPTION
I'm the faulty one concerning WAV, as i searched to stick to the more "standard" one, but afterward the most widely supported should have been choosed.

About M4A, i suspect that 90% users need `audio/mp4` MIME type by default, because AAC is far more supported / used than ALAC and most renderers support it as well. :tongue: 
That was my subversive PR :wink:

That's said, that will permit to clean later, all the renderers from unecessary audio MIME types entries

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/digitalmediaserver/digitalmediaserver/3)
<!-- Reviewable:end -->
