### PR TITLE
FPS implementation in renderer's configuration

### DIFF
--- a/src/main/external-resources/renderers/Samsung-9series.conf
+++ b/src/main/external-resources/renderers/Samsung-9series.conf
@@ -3,6 +3,7 @@
 # See DefaultRenderer.conf for descriptions of all the available options.
 #
 # Support MPO images as well (image/mpo)
+# issue: http://www.universalmediaserver.com/forum/posting.php?mode=reply&f=9&t=9249
 
 RendererName = Samsung 9 Series
 RendererIcon = Samsung-HU9000.png
@@ -30,10 +31,10 @@ LoadingPriority = 1
 
 TranscodeVideo = MPEGTS-H264-AC3
 TranscodeAudio = WAV
-#MaxVideoWidth = 3840
-#MaxVideoHeight = 2160
+MaxVideoWidth = 4096
+MaxVideoHeight = 2160
 SupportedVideoBitDepths = 8,10
-H264Level41Limited = true
+H264Level41Limited = false
 #H265Level51Limited = true
 SeekByTime = true
 DefaultVBVBufSize = false
@@ -45,30 +46,60 @@ CharMap = / :
 MediaInfo = true
 
 # Supported video formats:
-Supported = f:3gp|3g2  v:h264|mp4                                          a:aac-lc|he-aac                                     m:video/3gpp
-Supported = f:avi      v:divx|h263|h264|mjpeg|mp4|mpeg1|mpeg2|vc1|vp6|wmv  a:aac-lc|he-aac|ac3|eac3|lpcm|mp3|mpa|wma           m:video/avi                  gmc:0|1
-Supported = f:divx     v:divx|h263|h264|mjpeg|mp4|mpeg1|mpeg2|vc1|vp6|wmv  a:aac-lc|he-aac|ac3|eac3|lpcm|mp3|mpa|wma           m:video/x-divx
-Supported = f:flv      v:h263|h264|mp4|vp6                                 a:aac-lc|he-aac|mp3                                 m:video/x-flv
-Supported = f:mkv      v:h264|h265|mp4|mpeg1|mpeg2|vc1|vp6|wmv             a:aac-lc|he-aac|ac3|dts|dtshd|eac3|lpcm|mp3|mpa|wma m:video/x-mkv
-Supported = f:mkv      v:h263|h264|h265|mp4|mpeg1|mpeg2|vc1|vp6|wmv        a:vorbis                                            m:video/x-mkv                n:2
-Supported = f:mov      v:h263|h264|mjpeg|mp4|mpeg1|mpeg2|vc1|vp6|wmv       a:aac-lc|he-aac|ac3|eac3|lpcm|mp3|mpa|wma           m:video/quicktime
-Supported = f:mp4      v:h264|h265                                         a:aac-lc|he-aac|ac3|dts|dtshd|eac3|lpcm|mp3|mpa|wma m:video/mpeg
-Supported = f:mpegps   v:mpeg1|mpeg2                                       a:aac-lc|he-aac|ac3|lpcm|mp3|mpa                    m:video/mpeg
-Supported = f:mpegts   v:h264|h265|mp4|mpeg2                               a:aac-lc|he-aac|ac3|dts|dtshd|eac3|lpcm|mp3|mpa|wma m:video/vnd.dlna.mpeg-tts
-Supported = f:rm                                                           a:cook                                              m:video/vnd.rn-realvideo
-Supported = f:webm     v:vp8|vp9                                           a:vorbis                                            m:video/webm                 n:2
-Supported = f:wmv|asf  v:mp4|vc1|vp6|wmv                                   a:wma                                               m:video/x-ms-wmv
+Supported = f:3gp|3g2  v:h264                        a:aac-lc|he-aac                                     m:video/3gpp                 fps:60     b:60000000     v:3840     h:2160
+Supported = f:3gp|3g2  v:h264                        a:aac-lc|he-aac                                     m:video/3gpp                 fps:30     b:60000000     v:4096     h:2160
+Supported = f:3gp|3g2  v:mp4                         a:aac-lc|he-aac                                     m:video/3gpp                 fps:60     b:20000000     v:1920     h:1080
+Supported = f:avi      v:h264                        a:aac-lc|he-aac|ac3|eac3|lpcm|mp3|mpa|wma           m:video/avi                  fps:60     b:60000000     v:3840     h:2160     gmc:0|1
+Supported = f:avi      v:h264                        a:aac-lc|he-aac|ac3|eac3|lpcm|mp3|mpa|wma           m:video/avi                  fps:30     b:60000000     v:4096     h:2160     gmc:0|1
+Supported = f:avi      v:divx|mp4|mpeg1|mpeg2|vc1    a:aac-lc|he-aac|ac3|eac3|lpcm|mp3|mpa|wma           m:video/avi                  fps:60     b:20000000     v:1920     h:1080     gmc:0|1
+Supported = f:avi      v:h263|vp6|wmv                a:aac-lc|he-aac|ac3|eac3|lpcm|mp3|mpa|wma           m:video/avi                  fps:30     b:20000000     v:1920     h:1080     gmc:0|1
+Supported = f:avi      v:mjpeg                       a:aac-lc|he-aac|ac3|eac3|lpcm|mp3|mpa|wma           m:video/avi                  fps:30     b:80000000     v:4096     h:2160     gmc:0|1
+Supported = f:divx     v:h264                        a:aac-lc|he-aac|ac3|eac3|lpcm|mp3|mpa|wma           m:video/x-divx               fps:30     b:60000000     v:4096     h:2160
+Supported = f:divx     v:h264                        a:aac-lc|he-aac|ac3|eac3|lpcm|mp3|mpa|wma           m:video/x-divx               fps:60     b:60000000     v:3840     h:2160
+Supported = f:divx     v:mjpeg                       a:aac-lc|he-aac|ac3|eac3|lpcm|mp3|mpa|wma           m:video/x-divx               fps:30     b:80000000     v:4096     h:2160
+Supported = f:divx     v:divx|mp4|mpeg1|mpeg2|vc1    a:aac-lc|he-aac|ac3|eac3|lpcm|mp3|mpa|wma           m:video/x-divx               fps:60     b:20000000     v:1920     h:1080
+Supported = f:divx     v:h263|vp6|wmv                a:aac-lc|he-aac|ac3|eac3|lpcm|mp3|mpa|wma           m:video/x-divx               fps:30     b:20000000     v:1920     h:1080
+Supported = f:flv      v:h264                        a:aac-lc|he-aac|mp3                                 m:video/x-flv                fps:30     b:60000000     v:4096     h:2160
+Supported = f:flv      v:h264                        a:aac-lc|he-aac|mp3                                 m:video/x-flv                fps:60     b:60000000     v:3840     h:2160
+Supported = f:flv      v:mp4                         a:aac-lc|he-aac|mp3                                 m:video/x-flv                fps:60     b:20000000     v:1920     h:1080
+Supported = f:flv      v:h263|vp6                    a:aac-lc|he-aac|mp3                                 m:video/x-flv                fps:30     b:20000000     v:1920     h:1080
+Supported = f:mkv      v:h264                        a:aac-lc|he-aac|ac3|dts|dtshd|eac3|lpcm|mp3|mpa|wma m:video/x-mkv                fps:30     b:60000000     v:4096     h:2160
+Supported = f:mkv      v:h264                        a:aac-lc|he-aac|ac3|dts|dtshd|eac3|lpcm|mp3|mpa|wma m:video/x-mkv                fps:60     b:60000000     v:3840     h:2160
+Supported = f:mkv      v:mp4|vc1                     a:aac-lc|he-aac|ac3|dts|dtshd|eac3|lpcm|mp3|mpa|wma m:video/x-mkv                fps:60     b:20000000     v:1920     h:1080
+Supported = f:mkv      v:h265                        a:aac-lc|he-aac|ac3|dts|dtshd|eac3|lpcm|mp3|mpa|wma m:video/x-mkv                fps:60     b:80000000     v:4096     h:2160
+Supported = f:mkv      v:mpeg1|mpeg2                 a:aac-lc|he-aac|ac3|dts|dtshd|eac3|lpcm|mp3|mpa|wma m:video/x-mkv                fps:60     b:20000000     v:1920     h:1080
+Supported = f:mkv      v:vp6|wmv                     a:aac-lc|he-aac|ac3|dts|dtshd|eac3|lpcm|mp3|mpa|wma m:video/x-mkv                fps:30     b:20000000     v:1920     h:1080
+Supported = f:mkv      v:h264                        a:vorbis                                            m:video/x-mkv                fps:60     n:2     b:60000000     v:3840     h:2160
+Supported = f:mkv      v:h264                        a:vorbis                                            m:video/x-mkv                fps:30     n:2     b:60000000     v:4096     h:2160
+Supported = f:mkv      v:mp4|vc1                     a:vorbis                                            m:video/x-mkv                fps:60     n:2     b:20000000     v:1920     h:1080
+Supported = f:mkv      v:h265                        a:vorbis                                            m:video/x-mkv                fps:60     n:2     b:80000000     v:4096     h:2160
+Supported = f:mkv      v:mpeg1|mpeg2                 a:vorbis                                            m:video/x-mkv                fps:60     n:2     b:20000000     v:1920     h:1080
+Supported = f:mkv      v:h263|vp6|wmv                a:vorbis                                            m:video/x-mkv                fps:30     n:2     b:20000000     v:1920     h:1080
+Supported = f:mov      v:h263|vp6|wmv                a:aac-lc|he-aac|ac3|eac3|lpcm|mp3|mpa|wma           m:video/quicktime            fps:30     b:20000000             v:1920     h:1080
+Supported = f:mp4      v:h265                        a:aac-lc|he-aac|ac3|dts|dtshd|eac3|lpcm|mp3         m:video/mp4                  fps:60     b:80000000             v:4096     h:2160
+Supported = f:mp4      v:h264                        a:aac-lc|he-aac|ac3|dts|dtshd|eac3|lpcm|mp3         m:video/mp4                  fps:30     b:60000000             v:4096     h:2160
+Supported = f:mp4      v:h264                        a:aac-lc|he-aac|ac3|dts|dtshd|eac3|lpcm|mp3         m:video/mp4                  fps:60     b:60000000             v:3840     h:2160
+Supported = f:mpegps   v:mpeg1|mpeg2                 a:aac-lc|he-aac|ac3|lpcm|mp3|mpa                    m:video/mpeg                 fps:60     b:20000000             v:1920     h:1080
+Supported = f:mpegts   v:h264                        a:aac-lc|he-aac|ac3|dts|dtshd|eac3|lpcm|mp3|mpa|wma m:video/vnd.dlna.mpeg-tts    fps:30     b:60000000             v:4096     h:2160
+Supported = f:mpegts   v:h264                        a:aac-lc|he-aac|ac3|dts|dtshd|eac3|lpcm|mp3|mpa|wma m:video/vnd.dlna.mpeg-tts    fps:60     b:60000000             v:3840     h:2160
+Supported = f:mpegts   v:mp4                         a:aac-lc|he-aac|ac3|dts|dtshd|eac3|lpcm|mp3|mpa|wma m:video/vnd.dlna.mpeg-tts    fps:60     b:20000000             v:1920     h:1080
+Supported = f:mpegts   v:h265                        a:aac-lc|he-aac|ac3|dts|dtshd|eac3|lpcm|mp3|mpa|wma m:video/vnd.dlna.mpeg-tts    fps:60     b:80000000             v:4096     h:2160
+Supported = f:mpegts   v:mpeg2                       a:aac-lc|he-aac|ac3|dts|dtshd|eac3|lpcm|mp3|mpa|wma m:video/vnd.dlna.mpeg-tts    fps:60     b:20000000             v:1920     h:1080
+Supported = f:rm                                     a:cook                                              m:video/vnd.rn-realvideo     fps:60     b:20000000             v:1920     h:1080
+Supported = f:webm     v:vp8                         a:vorbis                                            m:video/webm                 fps:60     n:2     b:20000000     v:1920     h:1080
+Supported = f:webm     v:vp9                         a:vorbis                                            m:video/webm                 fps:60     n:2     b:40000000     v:4096     h:2160
+Supported = f:wmv|asf  v:mp4|vc1|vp6|wmv             a:wma|wma10|wmapro                                  m:video/x-ms-wmv             fps:30     b:20000000             v:1920     h:1080
 
 # Supported audio formats:
-Supported = f:aiff           m:audio/L16
-Supported = f:ape            m:audio/ape
-Supported = f:flac           m:audio/x-flac        n:2
-Supported = f:m4a|alac       m:audio/mp4
-Supported = f:mp3            m:audio/mpeg
-Supported = f:oga            m:audio/ogg
-Supported = f:vorbis         m:audio/vorbis        n:2
-Supported = f:wma            m:audio/x-ms-wma
-Supported = f:wav            m:audio/wav
+Supported = f:aiff                    m:audio/L16
+Supported = f:ape
+Supported = f:flac                                      n:2
+Supported = f:m4a      a:(?!alac)
+Supported = f:m4a      a:alac         m:audio/x-m4a
+Supported = f:mp3
+Supported = f:oga      a:vorbis                         n:2
+Supported = f:wma
+Supported = f:wav
 
 # Supported subtitles formats:
 SupportedExternalSubtitlesFormats = ASS,MICRODVD,SAMI,SUBRIP,TEXT

--- a/src/main/java/net/pms/configuration/FormatConfiguration.java
+++ b/src/main/java/net/pms/configuration/FormatConfiguration.java
@@ -20,6 +20,8 @@
 
 package net.pms.configuration;
 
+import static org.apache.commons.lang3.StringUtils.isBlank;
+import static org.apache.commons.lang3.StringUtils.isNotBlank;
 import java.io.IOException;
 import java.nio.channels.FileChannel;
 import java.nio.file.StandardOpenOption;
@@ -34,7 +36,6 @@ import net.pms.dlna.LibMediaInfoParser;
 import net.pms.formats.Format;
 import net.pms.formats.Format.Identifier;
 import net.pms.util.AudioUtils;
-import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -183,103 +184,144 @@ public class FormatConfiguration {
 		}
 
 		boolean isValid() {
-			if (StringUtils.isBlank(format)) { // required
-				LOGGER.warn("No format supplied");
+			if (isBlank(format)) { // required
+				LOGGER.error("No format specified on line \"{}\"", supportLine);
 				return false;
 			}
 			try {
 				pFormat = Pattern.compile(format);
 			} catch (PatternSyntaxException pse) {
-				LOGGER.error("Error parsing format \"{}\": {}", format, pse.getMessage());
+				LOGGER.error(
+					"Error parsing format \"{}\" from line \"{}\": {}",
+					format,
+					supportLine,
+					pse.getMessage()
+				);
 				LOGGER.trace("", pse);
 				return false;
 			}
 
-			if (videoCodec != null) {
+			if (isNotBlank(videoCodec)) {
 				try {
 					pVideoCodec = Pattern.compile(videoCodec);
 				} catch (PatternSyntaxException pse) {
-					LOGGER.error("Error parsing video codec \"{}\": {}", videoCodec, pse.getMessage());
+					LOGGER.error(
+						"Error parsing video codec \"{}\" from line \"{}\": {}",
+						videoCodec,
+						supportLine,
+						pse.getMessage()
+					);
 					LOGGER.trace("", pse);
 					return false;
 				}
 			}
 
-			if (audioCodec != null) {
+			if (isNotBlank(audioCodec)) {
 				try {
 					pAudioCodec = Pattern.compile(audioCodec);
 				} catch (PatternSyntaxException pse) {
-					LOGGER.error("Error parsing audio codec \"{}\": {}", audioCodec, pse.getMessage());
+					LOGGER.error(
+						"Error parsing audio codec \"{}\" from line \"{}\": {}",
+						audioCodec,
+						supportLine,
+						pse.getMessage()
+					);
 					LOGGER.trace("", pse);
 					return false;
 				}
 			}
 
-			if (maxNbChannels != null) {
+			if (isNotBlank(maxNbChannels)) {
 				try {
 					iMaxNbChannels = Integer.parseInt(maxNbChannels);
 				} catch (NumberFormatException nfe) {
-					LOGGER.error("Error parsing number of channels \"{}\": {}", maxNbChannels, nfe.getMessage());
+					LOGGER.error(
+						"Error parsing number of channels \"{}\" from line \"{}\": {}",
+						maxNbChannels,
+						supportLine,
+						nfe.getMessage()
+					);
 					LOGGER.trace("", nfe);
 					return false;
 				}
 			}
 
-			if (maxFramerate != null) {
+			if (isNotBlank(maxFramerate)) {
 				try {
 					iMaxFramerate = Integer.parseInt(maxFramerate);
 				} catch (NumberFormatException nfe) {
-					LOGGER.error("Error parsing maximum framerate \"{}\": {}", maxFramerate, nfe.getMessage());
+					LOGGER.error(
+						"Error parsing maximum framerate \"{}\" from line \"{}\": {}",
+						maxFramerate,
+						supportLine,
+						nfe.getMessage()
+					);
 					LOGGER.trace("", nfe);
 					return false;
 				}
 			}
 
-			if (maxFrequency != null) {
+			if (isNotBlank(maxFrequency)) {
 				try {
 					iMaxFrequency = Integer.parseInt(maxFrequency);
 				} catch (NumberFormatException nfe) {
-					LOGGER.error("Error parsing maximum frequency \"{}\": {}", maxFrequency, nfe.getMessage());
+					LOGGER.error(
+						"Error parsing maximum frequency \"{}\" from line \"{}\": {}",
+						maxFrequency,
+						supportLine,
+						nfe.getMessage()
+					);
 					LOGGER.trace("", nfe);
 					return false;
 				}
 			}
 
-			if (maxBitrate != null) {
+			if (isNotBlank(maxBitrate)) {
 				try {
 					iMaxBitrate = Integer.parseInt(maxBitrate);
 				} catch (NumberFormatException nfe) {
-					LOGGER.error("Error parsing maximum bitrate \"{}\": {}", maxBitrate, nfe.getMessage());
+					LOGGER.error(
+						"Error parsing maximum bitrate \"{}\" from line \"{}\": {}",
+						maxBitrate,
+						supportLine,
+						nfe.getMessage()
+					);
 					LOGGER.trace("", nfe);
 					return false;
 				}
 			}
 
-			if (maxVideoWidth != null) {
+			if (isNotBlank(maxVideoWidth)) {
 				try {
 					iMaxVideoWidth = Integer.parseInt(maxVideoWidth);
 				} catch (NumberFormatException nfe) {
-					LOGGER.error("Error parsing maximum video width \"{}\": {}", maxVideoWidth, nfe.getMessage());
+					LOGGER.error(
+						"Error parsing maximum video width \"{}\" from line \"{}\": {}",
+						maxVideoWidth,
+						supportLine,
+						nfe.getMessage()
+					);
 					LOGGER.trace("", nfe);
 					return false;
 				}
 			}
 
-			if (maxVideoHeight != null) {
+			if (isNotBlank(maxVideoHeight)) {
 				try {
 					iMaxVideoHeight = Integer.parseInt(maxVideoHeight);
 				} catch (NumberFormatException nfe) {
-					LOGGER.error("Error parsing maximum video height \"{}\": {}", maxVideoHeight, nfe.getMessage());
+					LOGGER.error(
+						"Error parsing maximum video height \"{}\" from line \"{}\": {}",
+						maxVideoHeight,
+						supportLine,
+						nfe.getMessage()
+					);
 					LOGGER.trace("", nfe);
 					return false;
 				}
 			}
 
 			return true;
-		}
-
-		public boolean match(String container, String videoCodec, String audioCodec) {
-			return match(container, videoCodec, audioCodec, 0, 0, 0, 0, 0, 0, null);
 		}
 
 		/**
@@ -390,7 +432,12 @@ public class FormatConfiguration {
 						return false;
 					}
 
-					if (key.equals(MI_GOP) && miExtras.get(MI_GOP) != null && miExtras.get(MI_GOP).matcher("static").matches() && value.equals("variable")) {
+					if (
+						key.equals(MI_GOP) &&
+						miExtras.get(MI_GOP) != null &&
+						miExtras.get(MI_GOP).matcher("static").matches() &&
+						value.equals("variable")
+					) {
 						LOGGER.trace("GOP value \"{}\" failed to match support line {}", value, supportLine);
 						return false;
 					}
@@ -416,11 +463,6 @@ public class FormatConfiguration {
 				}
 			}
 		}
-	}
-
-	@Deprecated
-	public void parse(DLNAMediaInfo media, InputFile file, Format ext, int type) {
-		parse(media, file, ext, type, null);
 	}
 
 	/**
@@ -461,12 +503,6 @@ public class FormatConfiguration {
 		}
 	}
 
-	// XXX Unused
-	@Deprecated
-	public boolean isDVDVideoRemuxSupported() {
-		return match(MPEGPS, MPEG2, null) != null;
-	}
-
 	public boolean isFormatSupported(String container) {
 		return match(container, null, null) != null;
 	}
@@ -483,54 +519,6 @@ public class FormatConfiguration {
 		return match(MPEGPS, MPEG2, null) != null || match(MPEGTS, MPEG2, null) != null;
 	}
 
-	// XXX Unused
-	@Deprecated
-	public boolean isHiFiMusicFileSupported() {
-		return match(WAV, null, null, 0, 96000, 0, 0, 0, 0, null) != null || match(MP3, null, null, 0, 96000, 0, 0, 0, 0, null) != null;
-	}
-
-	// XXX Unused
-	@Deprecated
-	public String getPrimaryVideoTranscoder() {
-		for (SupportSpec supportSpec : supportSpecs) {
-			if (supportSpec.match(MPEGPS, MPEG2, AC3)) {
-				return MPEGPS;
-			}
-
-			if (
-				supportSpec.match(MPEGTS, MPEG2, AC3) ||
-				supportSpec.match(MPEGTS, H264, AAC_LC) ||
-				supportSpec.match(MPEGTS, H264, AC3)
-			) {
-				return MPEGTS;
-			}
-
-			if (supportSpec.match(WMV, WMV, WMA)) {
-				return WMV;
-			}
-		}
-
-		return null;
-	}
-
-	// XXX Unused
-	@Deprecated
-	public String getPrimaryAudioTranscoder() {
-		for (SupportSpec supportSpec : supportSpecs) {
-			if (supportSpec.match(WAV, null, null)) {
-				return WAV;
-			}
-
-			if (supportSpec.match(MP3, null, null)) {
-				return MP3;
-			}
-
-			// FIXME LPCM?
-		}
-
-		return null;
-	}
-
 	/**
 	 * Match media information to audio codecs supported by the renderer and
 	 * return its MIME-type if the match is successful. Returns null if the
@@ -541,16 +529,25 @@ public class FormatConfiguration {
 	 * @return The MIME type or null if no match was found.
 	 */
 	public String match(DLNAMediaInfo media) {
+		if (media == null) {
+			return null;
+		}
+		int frameRate = 0;
+		if (isNotBlank(media.getFrameRate())) {
+			try {
+				frameRate = (int) Math.round(Double.parseDouble(media.getFrameRate()));
+			} catch (NumberFormatException e) {
+				LOGGER.debug(
+					"Could not parse framerate \"{}\" for media {}: {}",
+					media.getFrameRate(),
+					media,
+					e.getMessage()
+				);
+				LOGGER.trace("", e);
+			}
+		}
 		if (media.getFirstAudioTrack() == null) {
 			// no sound
-			int frameRate = 0;
-			if (StringUtils.isNotBlank(media.getFrameRate())) {
-				try {
-					frameRate = (int) Math.round(Double.parseDouble(media.getFrameRate()));
-				} catch (NumberFormatException e) {
-					LOGGER.debug("Could not parse the framerate: " + e);
-				}
-			}
 			return match(
 				media.getContainer(),
 				media.getCodecV(),
@@ -577,14 +574,6 @@ public class FormatConfiguration {
 			 * track needs to be checked.
 			 */
 			DLNAMediaAudio audio = media.getFirstAudioTrack();
-			int frameRate = 0;
-			if (StringUtils.isNotBlank(media.getFrameRate())) {
-				try {
-					frameRate = (int) Math.round(Double.parseDouble(media.getFrameRate()));
-				} catch (NumberFormatException e) {
-					LOGGER.debug("Could not parse the framerate: " + e);
-				}
-			}
 			return match(
 				media.getContainer(),
 				media.getCodecV(),
@@ -602,14 +591,6 @@ public class FormatConfiguration {
 		String finalMimeType = null;
 
 		for (DLNAMediaAudio audio : media.getAudioTracksList()) {
-			int frameRate = 0;
-			if (StringUtils.isNotBlank(media.getFrameRate())) {
-				try {
-					frameRate = (int) Math.round(Double.parseDouble(media.getFrameRate()));
-				} catch (NumberFormatException e) {
-					LOGGER.debug("Could not parse the framerate: " + e);
-				}
-			}
 			String mimeType = match(
 				media.getContainer(),
 				media.getCodecV(),


### PR DESCRIPTION
To be able to fine tune the renderer's configuration supported lines.

A DLNA profiles implementation will not be able to do that for DMP and UPnP renderers.

**Note**: Since i don't know yet how to clean the mess in my fork, so i pushed a clean version from here.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/digitalmediaserver/digitalmediaserver/10)
<!-- Reviewable:end -->
