### PR TITLE
Update CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -32,4 +32,4 @@ We welcome Pull Requests. Please be descriptive about the purpose of the code ch
 
 GitHub only allows a few attachment extensions: `.png`, `.gif`, `.jpg`, `.docx`, `.pptx`, `.xlsx`, `.txt`, `.pdf`, `.zip` and `.gz`. Other attachments can be zipped and attached here. Text files can also simply have a `.txt` extension added to their file name.
 
-GitHub has a size limit of 20 MB for attachments. If your attachment is too big, upload your attachment somewhere else (for example [wikisend.com](http://wikisend.com)) and post the link in the GitHub issue. If you upload your attachment elsewhere, please avoid sites with restricted access or intrusive ads.
+GitHub has a size limit of 20 MB for attachments. If your attachment is too big, upload your attachment somewhere else (for example [wikisend.com](http://wikisend.com), [zippyshare.com](http://www.zippyshare.com), [send-anywhere.com](https://send-anywhere.com), [ge.tt](http://ge.tt) or [anonfile.com](https://anonfile.com)) and post the link in the GitHub issue. If you upload your attachment elsewhere, please avoid sites with restricted access or intrusive ads.


### PR DESCRIPTION
As some sites could become paid services or being closed, better to have the choice, and save everyone the trouble to search again for alternatives. Some have bigger upload size, from 200 MB until 5 GB, and duration control or download time control.

https://www.filedog.io/ could also have been added.
https://filedepot.net/ never worked for me.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/digitalmediaserver/digitalmediaserver/30)
<!-- Reviewable:end -->
