### PR TITLE
Extend MP4 SLS support

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -88,7 +88,7 @@
 		<project.binaries>${project.basedir}/target/bin</project.binaries>
 
 		<project.binaries-base>http://universalmediaserver.com/svn/binaries</project.binaries-base>
-		<binary-revision>67</binary-revision>
+		<binary-revision>71</binary-revision>
 
 		<maven-javadoc-plugin-version>3.0.0</maven-javadoc-plugin-version>
 		<git-commit-id-plugin-version>2.2.4</git-commit-id-plugin-version>

--- a/src/main/external-resources/renderers/DefaultRenderer.conf
+++ b/src/main/external-resources/renderers/DefaultRenderer.conf
@@ -586,6 +586,7 @@ CharMap =
 #    dtshd    Digital Theater Systems (HD)                  audio/vnd.dts.hd
 #    dv       Digital Video                                 video/dv
 #    eac3     Enhanced AC-3 (Dolby Digital Plus, DD+)       audio/eac3
+#    erbsac   Error Resilient Bit-Sliced Arithmetic Coding
 #    ffv1     FF video codec 1
 #    flac     Free Lossless Audio Codec                     audio/x-flac
 #    flv      Flash Video                                   video/x-flv

--- a/src/main/java/net/pms/configuration/FormatConfiguration.java
+++ b/src/main/java/net/pms/configuration/FormatConfiguration.java
@@ -76,6 +76,7 @@ public class FormatConfiguration {
 	public static final String DTSHD = "dtshd";
 	public static final String DV = "dv";
 	public static final String EAC3 = "eac3";
+	public static final String ER_BSAC = "erbsac";
 	public static final String FFV1 = "ffv1";
 	public static final String FLAC = "flac";
 	public static final String FLV = "flv";

--- a/src/main/java/net/pms/dlna/DLNAMediaAudio.java
+++ b/src/main/java/net/pms/dlna/DLNAMediaAudio.java
@@ -248,6 +248,13 @@ public class DLNAMediaAudio extends DLNAMediaLang implements Cloneable {
 	}
 
 	/**
+	 * @return whether the audio codec is ER BSAC.
+	 */
+	public boolean isERBSAC() {
+		return FormatConfiguration.ER_BSAC.equalsIgnoreCase(getCodecA());
+	}
+
+	/**
 	 * @return True if the audio codec is FLAC.
 	 */
 	public boolean isFLAC() {
@@ -492,6 +499,8 @@ public class DLNAMediaAudio extends DLNAMediaLang implements Cloneable {
 			return "DTS HD";
 		} else if (isEAC3()) {
 			return "Enhanced AC-3";
+		} else if (isERBSAC()) {
+			return "ER BSAC";
 		} else if (isFLAC()) {
 			return "FLAC";
 		} else if (isG729()) {

--- a/src/main/java/net/pms/dlna/DLNAMediaInfo.java
+++ b/src/main/java/net/pms/dlna/DLNAMediaInfo.java
@@ -365,20 +365,25 @@ public class DLNAMediaInfo implements Cloneable {
 	 * core layer. Valid cores include AAC-LC, AAC Scalable (without LTP), ER
 	 * AAC LC, ER AAC Scalable, and ER BSAC.
 	 * <p>
-	 * Since DMS currently only implements AAC-LC among the valid core layer
-	 * codecs, AAC-LC is the only core layer format "approved" by this test. If
-	 * further codecs are added in the future, this test should be modified
-	 * accordingly.
+	 * DMS currently only implements AAC-LC and ER BSAC among the valid core
+	 * layer codecs, so only those are "approved" by this test. If further
+	 * codecs are added in the future, this test should be modified accordingly.
 	 *
-	 * @return {@code true} is this {@link DLNAMediaInfo} instance has two audio
-	 *         tracks where the first has codec AAC-LC and the second has codec
-	 *         SLS, {@code false} otherwise.
+	 * @return {@code true} if this {@link DLNAMediaInfo} instance has two audio
+	 *         tracks where the first has an approved AAC codec and the second
+	 *         has codec SLS, {@code false} otherwise.
 	 */
 	public boolean isSLS() {
 		if (audioTracks.size() != 2) {
 			return false;
 		}
-		return audioTracks.get(0).isAACLC() && audioTracks.get(1).isSLS();
+
+		return
+			(
+				audioTracks.get(0).isAACLC() ||
+				audioTracks.get(0).isERBSAC()
+			) &&
+			audioTracks.get(1).isSLS();
 	}
 
 	public MediaType getMediaType() {

--- a/src/main/java/net/pms/dlna/LibMediaInfoParser.java
+++ b/src/main/java/net/pms/dlna/LibMediaInfoParser.java
@@ -460,16 +460,27 @@ public class LibMediaInfoParser {
 	}
 
 	/**
-	 * Sends the correct information to media.setContainer(),
-	 * media.setCodecV() or media.setCodecA, depending on streamType.
+	 * Sets the correct information in media.setContainer(), media.setCodecV()
+	 * or media.setCodecA, depending on streamType.
 	 *
-	 * TODO: Rename to something like setFormat - this is not a getter.
+	 * Note: A lot of these are types of MPEG-4 Audio. A good resource to make
+	 * sense of this is: <a href=
+	 * "https://en.wikipedia.org/wiki/MPEG-4_Part_3#MPEG-4_Audio_Object_Types"
+	 * >MPEG-4 Audio Object Types</a>
+	 * <p>
+	 * There are also free samples of most of them at <a
+	 * href="http://fileformats.archiveteam.org/wiki/MPEG-4_SLS"
+	 * >fileformats.archiveteam.org</a> and <a href=
+	 * "ftp://mpaudconf:adif2mp4@ftp.iis.fhg.de/mpeg4audio-conformance/compressedMp4/"
+	 * >ftp.iis.fhg.de</a>
 	 *
 	 * @param streamType
 	 * @param media
 	 * @param audio
 	 * @param value
 	 * @param file
+	 *
+	 * TODO: Refactor this pain of a method
 	 */
 	private static void getFormat(
 		StreamType streamType,
@@ -508,7 +519,7 @@ public class LibMediaInfoParser {
 			streamType != StreamType.Audio && value.startsWith("mp4") && !value.startsWith("mp4a") ||
 			value.equals("20") ||
 			value.equals("isml") ||
-			value.startsWith("m4a") ||
+			(value.startsWith("m4a") && !value.startsWith("m4ae")) ||
 			value.startsWith("m4v") ||
 			value.equals("mpeg-4 visual") ||
 			value.equals("xavc")
@@ -689,11 +700,17 @@ public class LibMediaInfoParser {
 				FormatConfiguration.AVI.equals(media.getContainer())
 			)
 		) {
+			// mp4a-40-2, enca-67-2
 			format = FormatConfiguration.AAC_LC;
 		} else if (value.equals("ltp")) {
 			format = FormatConfiguration.AAC_LTP;
 		} else if (value.contains("he-aac")) {
 			format = FormatConfiguration.HE_AAC;
+		} else if (
+			value.equals("er bsac") ||
+			value.equals("mp4a-40-22")
+		) {
+			format = FormatConfiguration.ER_BSAC;
 		} else if (value.equals("main")) {
 			format = FormatConfiguration.AAC_MAIN;
 		} else if (value.equals("ssr")) {
@@ -735,6 +752,7 @@ public class LibMediaInfoParser {
 		} else if (value.equals("shorten")) {
 			format = FormatConfiguration.SHORTEN;
 		} else if (value.equals("sls") || value.equals("SLS non-core")) {
+			// m4ae-40-37 until this MediaInfo bug get fixed, or mp4a-40-38 for non-core
 			format = FormatConfiguration.SLS;
 		} else if (value.equals("acelp")) {
 			format = FormatConfiguration.ACELP;
@@ -1008,6 +1026,7 @@ public class LibMediaInfoParser {
 	 *
 	 * @deprecated Parse "Duration" with {@link #parseDuration(String)} instead.
 	 */
+	@SuppressWarnings("unused")
 	@Deprecated
 	private static double getDuration(String value) {
 		int h = 0, m = 0, s = 0;

--- a/src/main/java/net/pms/dlna/LibMediaInfoParser.java
+++ b/src/main/java/net/pms/dlna/LibMediaInfoParser.java
@@ -326,7 +326,7 @@ public class LibMediaInfoParser {
 			/*
 			 * Some container formats (like MP4/M4A) can represent both audio
 			 * and video media. DMS initially recognized this as video, but this
-			 * is corrected here it the content is only audio.
+			 * is corrected here if the content is only audio.
 			 */
 			if (media.isAudioOrVideoContainer() && media.isAudio()) {
 				media.setContainer(media.getAudioVariantFormatConfigurationString());
@@ -505,7 +505,7 @@ public class LibMediaInfoParser {
 			format = FormatConfiguration.MOV;
 		} else if (
 			value.contains("isom") ||
-			value.startsWith("mp4") && !value.startsWith("mp4a")||
+			streamType != StreamType.Audio && value.startsWith("mp4") && !value.startsWith("mp4a") ||
 			value.equals("20") ||
 			value.equals("isml") ||
 			value.startsWith("m4a") ||
@@ -548,8 +548,8 @@ public class LibMediaInfoParser {
 			value.equals("wmv2")
 		) {
 			format = FormatConfiguration.WMV;
-		} else if (streamType == StreamType.Video &&
-			(
+		} else if (
+			streamType == StreamType.Video && (
 				value.contains("mjpg") ||
 				value.contains("mjpeg") ||
 				value.equals("mjpa") ||

--- a/sync.txt
+++ b/sync.txt
@@ -1,4 +1,4 @@
-UMS sync with: d9d1ee008625d6ee53689a4e30a1631e5c9bad07 Added extra prettifying test and helper functions
+UMS sync with: d45fa1e1e984f1ce1072d728b7cb14e1b5415eb2 Updated MediaInfo to 18.03.1
 
 Skipped:
 a4a099c7efcaf6dc8a28402a29eade757a2ce78d The ugly hack to solve problem when the TotalMatches are changed
@@ -25,6 +25,12 @@ cede0c88fafcd59229f25666b0dbb871e65eea57 Fixed "By Date" virtual folders on join
 b9268bbd67a332054b898fcfc03e55e12e8e9d5e Order the "By date" folders from newest to oldest
 2d0dacd6b9231197a3df4d73ac773520ca275072 Fix bug in updating the database when is not created.
 1e6b1151faa47e0687d6ff6bce5bacf1d857aed4 Bump to 7.0.0-SNAPSHOT
+761995b7de52fe3af76dbae68efe1891e16f719d Sync translations with Crowdin
+4d972a24341361e9ad25e31bf430f1aa24048959 Updated changelog
+420784dcca6ba8fc17fcfc4f77fc7e9b0417860d Updated changelog
+2fbf7f3212e993d3cb94892f888148efd0d843fc Synchronized translations with Crowdin
+e2000b4755973d0d92ea21eae778d239d3047224 7.0.0
+d3a045bdb3585f1fbf7cdc808236cac646461cb7 Bump to 7.0.1-SNAPSHOT
 a83d67c77df019c316eb253511202c2ffaf6ad03 Enabled automatic updating on Windows to 7.0.0
 79a4c750a4f3735127179dc0b156b15f74c0365a Added config for newer Roku devices
 60f8de4cd37e58f544588c89dbc359503019ee20 Create Roku-TV8.conf
@@ -35,4 +41,9 @@ e4524f079d1eea57ebdea872e06817b6f1c703c4 Post-7.0.0 updated to UMS.conf (partial
 401b94f671b07701908c373e7db7e2bbff97e0a6 Fixed bug with JPEG_LRG profile check
 1a15b38761b610b8cf10cceca1ea71024da9656d Faster hashing v2
 a8ea983105a88083d088e2138020591d5787af81 Drop experimental FFmpeg flag
-761995b7de52fe3af76dbae68efe1891e16f719d Sync translations with Crowdin
+9ff5b63fa9e8d72c9720835a1bfb35cedc29a21a Don't use global ID repository during cache scan
+76fa1b8de804cd596aa9a9256224d22a22b95a30 Synchronized translations with Crowdin
+185b243f371e47201bd78206743019f6b15028d0 7.0.1
+f6df7f873a51ae57533e1a2a129260f115d9b1b9 Bump to 7.0.2-SNAPSHOT
+a7fcf7108352314493dbd5cec5cb06df186da815 Bump Windows automatic updater to 7.0.1
+81e3215cc6a3f993626a1c9cc159ed96d98de2db Removed unnecessary logging


### PR DESCRIPTION
This is a cherry-pick of https://github.com/UniversalMediaServer/UniversalMediaServer/pull/1423.

@Sami32 You you please look through and correct this as needed. I don't really followed you guys on the details, so I'm not sure if what I've done is correct.

Please keep in mind that we don't want it to only work with the latest version of MediaInfo, so try not to make any assumptions about the version used. Users can use any version they want of MediaInfo, and on Linux this is pretty much decided by which version is packaged with the system. It's often easy to make the code work with both old and new versions.

This needs further cleaning up of the commits before merging, but I can't do it until I know what the final outcome will be so I will do that once the corrections are made.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/digitalmediaserver/digitalmediaserver/37)
<!-- Reviewable:end -->
