### PR TITLE
Replace unrar library

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -166,6 +166,12 @@
 				Check the commons-logging:commons-logging version of the other libraries before upgrading
 			-->
 			<version>1.10</version>
+			<exclusions>
+				<exclusion>
+					<groupId>commons-logging</groupId>
+					<artifactId>commons-logging</artifactId>
+				</exclusion>
+			</exclusions>
 		</dependency>
 		<dependency>
 			<groupId>commons-io</groupId>
@@ -344,7 +350,7 @@
 
 				Check the commons-logging:commons-logging version of the other libraries before upgrading
 			-->
-			<version>0.7</version>
+			<version>1.0.0</version>
 		</dependency>
 
 		<!-- XXX: not Mavenized: https://code.google.com/p/cuelib/ -->
@@ -484,6 +490,10 @@
 				<exclusion>
 					<groupId>commons-io</groupId>
 					<artifactId>commons-io</artifactId>
+				</exclusion>
+				<exclusion>
+					<groupId>commons-logging</groupId>
+					<artifactId>commons-logging</artifactId>
 				</exclusion>
 			</exclusions>
 		</dependency>

--- a/src/main/java/net/pms/dlna/virtual/VirtualFolder.java
+++ b/src/main/java/net/pms/dlna/virtual/VirtualFolder.java
@@ -20,9 +20,9 @@ package net.pms.dlna.virtual;
 
 import java.io.IOException;
 import java.io.InputStream;
+import org.apache.commons.lang3.StringUtils;
 import net.pms.dlna.DLNAResource;
 import net.pms.dlna.DLNAThumbnailInputStream;
-import org.codehaus.plexus.util.StringUtils;
 
 /**
  * Represents a container (folder). This is widely used by the UPNP ContentBrowser service. Child objects are expected in this folder.

--- a/src/main/java/net/pms/util/FileUtil.java
+++ b/src/main/java/net/pms/util/FileUtil.java
@@ -42,9 +42,9 @@ import net.pms.util.StringUtil.LetterCase;
 import static net.pms.util.Constants.*;
 import static org.apache.commons.lang3.StringUtils.*;
 import org.apache.commons.io.FilenameUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.text.WordUtils;
 import org.apache.commons.text.similarity.JaroWinklerDistance;
-import org.codehaus.plexus.util.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/src/main/java/net/pms/util/TempFileMgr.java
+++ b/src/main/java/net/pms/util/TempFileMgr.java
@@ -29,8 +29,8 @@ import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Timer;
 import java.util.TimerTask;
+import org.apache.commons.lang3.StringUtils;
 import net.pms.PMS;
-import org.codehaus.plexus.util.StringUtils;
 
 public class TempFileMgr {
 	private static final int DEFAULT_CLEAN_TIME = 14 * 24 * 3600 * 1000;


### PR DESCRIPTION
### Update: 
[com.github.axet:java-unrar](https://gitlab.com/axet/java-unrar) turned out to be even less updated in many way and to lack essential fixes. Instead, https://github.com/junrar/junrar/pull/7 has been merged and version ```1.0.0``` of [com.github.junrar:junrar](https://github.com/junrar/junrar) has been released.

This PR now takes the new version of the original artifact in use.

### Original text:
This replaces the ancient [com.github.junrar:junrar](https://github.com/edmund-wagner/junrar ) with [com.github.axet:java-unrar](https://gitlab.com/axet/java-unrar) to avoid some very old dependencies.

These are both descendants of the same code, but I haven't checked what is different in the implementations except for updated dependencies in the latter.

This needs testing.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/digitalmediaserver/digitalmediaserver/38)
<!-- Reviewable:end -->
