### PR TITLE
ATRAC fix

### DIFF
--- a/src/main/java/net/pms/dlna/LibMediaInfoParser.java
+++ b/src/main/java/net/pms/dlna/LibMediaInfoParser.java
@@ -825,7 +825,7 @@ public class LibMediaInfoParser {
 			} else if (value.equals("wma10")) {
 				format = FormatConfiguration.WMA10;
 			}
-		} else if (value.equals("flac") || "19d".equals(value)) { // "19d" due to a flaw in MediaInfo code
+		} else if (value.equals("flac") || "19d".equals(value)) { // https://github.com/MediaArea/MediaInfoLib/issues/594
 			format = FormatConfiguration.FLAC;
 		} else if (value.equals("monkey's audio")) {
 			format = FormatConfiguration.MONKEYS_AUDIO;
@@ -837,8 +837,11 @@ public class LibMediaInfoParser {
 			format = FormatConfiguration.MLP;
 		} else if (value.equals("openmg")) {
 			format = FormatConfiguration.ATRAC;
-		} else if (value.startsWith("atrac")) {
+		} else if (value.startsWith("atrac") || value.endsWith("-a119-fffa01e4ce62") || value.endsWith("-88fc-61654f8c836c")) {
 			format = FormatConfiguration.ATRAC;
+			if (streamType == StreamType.Audio && !FormatConfiguration.ATRAC.equals(media.getContainer())) {
+				media.setContainer(FormatConfiguration.ATRAC);
+			}
 		} else if (value.equals("nellymoser")) {
 			format = FormatConfiguration.NELLYMOSER;
 		} else if (value.equals("jpeg")) {


### PR DESCRIPTION
https://github.com/MediaArea/MediaInfoLib/issues/898
https://github.com/MediaArea/MediaInfoLib/issues/897

Making it more perfect, without sure benefice, will add more MediaInfo value be added so slowing the general parsing process. Then i consider this fix as a good compromise until it get fixed by MediaInfo and perhaps in FFmpeg as well.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/digitalmediaserver/digitalmediaserver/51)
<!-- Reviewable:end -->
