### PR TITLE
Dolby E

### DIFF
--- a/src/main/java/net/pms/configuration/FormatConfiguration.java
+++ b/src/main/java/net/pms/configuration/FormatConfiguration.java
@@ -72,6 +72,7 @@ public class FormatConfiguration {
 	public static final String DIVX = "divx";
 	/** Direct Stream Digital / Super Audio CD tracks */
 	public static final String DFF = "dff";
+	public static final String DOLBYE = "dolbye";
 	public static final String DSF = "dsf";
 	public static final String DTS = "dts";
 	public static final String DTSHD = "dtshd";

--- a/src/main/java/net/pms/dlna/DLNAMediaAudio.java
+++ b/src/main/java/net/pms/dlna/DLNAMediaAudio.java
@@ -197,6 +197,13 @@ public class DLNAMediaAudio extends DLNAMediaLang implements Cloneable {
 	}
 
 	/**
+	 * @return True if the audio codec is Dolby E.
+	 */
+	public boolean isDOLBYE() {
+		return FormatConfiguration.DOLBYE.equalsIgnoreCase(getCodecA());
+	}
+
+	/**
 	 * @return True if the audio codec is DSF.
 	 */
 	public boolean isDSF() {
@@ -464,6 +471,8 @@ public class DLNAMediaAudio extends DLNAMediaLang implements Cloneable {
 			return "Cook";
 		} else if (isDFF()) {
 			return "DFF";
+		} else if (isDOLBYE()) {
+			return "Dolby E";
 		} else if (isDSF()) {
 			return "DSF";
 		} else if (isDTS()) {

--- a/src/main/java/net/pms/dlna/LibMediaInfoParser.java
+++ b/src/main/java/net/pms/dlna/LibMediaInfoParser.java
@@ -696,6 +696,8 @@ public class LibMediaInfoParser {
 			format = FormatConfiguration.ADTS;
 		} else if (value.startsWith("amr")) {
 			format = FormatConfiguration.AMR;
+		} else if (value.equals("dolby e")) {
+			format = FormatConfiguration.DOLBYE;
 		} else if (
 			value.equals("ac-3") ||
 			value.equals("a_ac3") ||

--- a/src/test/java/net/pms/configuration/FormatConfigurationRegressionTest0.java
+++ b/src/test/java/net/pms/configuration/FormatConfigurationRegressionTest0.java
@@ -881,4 +881,12 @@ public class FormatConfigurationRegressionTest0 {
 		// Regression assertion (captures the current behavior of the code)
 		assertTrue("'" + str0 + "' != '" + "mpeg4sp"+ "'", str0.equals("mpeg4sp"));
 	}
+
+	@Test
+	public void testDOLBYE() throws Throwable {
+		String str0 = net.pms.configuration.FormatConfiguration.DOLBYE;
+
+		// Regression assertion (captures the current behavior of the code)
+		assertTrue("'" + str0 + "' != '" + "dolbye"+ "'", str0.equals("dolbye"));
+	}
 }


### PR DESCRIPTION
https://wiki.multimedia.cx/index.php?title=Dolby_E

Mainly to be able to see it without asking for MediaInfo log, for now at least.
No support planned as it is more for professional use and i don't know of any popular renderer supporting it.

Note:
https://github.com/FFmpeg/FFmpeg/commit/f04ef268164f7e88bef809fb028c6fa01b024ea3

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/digitalmediaserver/digitalmediaserver/58)
<!-- Reviewable:end -->
